### PR TITLE
Fix trying to load non importable directories

### DIFF
--- a/lib/filter-empty-dir.js
+++ b/lib/filter-empty-dir.js
@@ -1,0 +1,22 @@
+'use strict';
+const join = require('path').join;
+const lstat = require('fs').lstatSync;
+const exists = require('fs').existsSync;
+/**
+ * We want to filter out directories that
+ * are not able to be required, that is
+ * directories that do not have an index.js
+ * file.
+ * @param  {Array} list List of filepaths
+ * @return {Array}
+ */
+function filterEmptyDir(list=[]) {
+    return list.map((f)=>{
+        if(lstat(f).isDirectory() && !exists(join(f, 'index.js'))) {
+            return false;
+        }
+        return f;
+    }).filter(Boolean);
+}
+
+module.exports = filterEmptyDir;

--- a/lib/in.js
+++ b/lib/in.js
@@ -9,7 +9,6 @@
 'use strict';
 
 const extend = require('gextend');
-
 const join = require('path').join;
 const readdir = require('fs').readdir;
 const separator = require('path').sep;
@@ -23,6 +22,7 @@ const multimatch = require('multimatch');
 
 const _normalize = require('./normalizeArguments');
 const _isDevelopment = require('./isDevelopment');
+const _filterEmptyDir = require('./filter-empty-dir');
 
 var DEFAULTS = {
     logger: console,
@@ -74,15 +74,19 @@ class PluginLoader {
      *  * `target` {String} Path to scan
      *  Returns Array {Array} Array containing absolute paths to all files in target
      */
-    find(target){
+    find(target) {
         if(!this.isPluginId(target) && !isAbsolute(target)){
             target = this.normalizePath(target, this.basepath);
         }
 
-        return new Promise(function(resolve, reject){
-            readdir(target, function(err, list){
+        return new Promise((resolve, reject)=>{
+            readdir(target,(err, list)=>{
                 if(err) return reject(err);
+
                 list = list.map((f) => join(target, f));
+
+                list = _filterEmptyDir(list);
+
                 resolve(list);
             });
         });
@@ -129,7 +133,7 @@ class PluginLoader {
         plugins.map((bean) => {
             bean.isLocal = true;
             try {
-                if(exists(bean.path)){
+                if(exists(bean.path)) {
                     bean.plugin = require(bean.path);
                 }
                 else if(exists(bean.path + '.js')) {


### PR DESCRIPTION
If we are trying to mount a directory that has empty folders- or more accurately folders without an `index.js` file- we throw an error. This behavior is now prevented by filtering out paths before returning a list of files in the `in.find` function.